### PR TITLE
Include information on maximum credential size

### DIFF
--- a/using.html.md.erb
+++ b/using.html.md.erb
@@ -26,7 +26,7 @@ Run the following command:
 	* `SERVICE-INSTANCE` is a name for your new service instance. 
 	* `CREDENTIAL-NAME` is the name for the credential you want to provide to services that are not running on PAS.
 	* `CREDENTIAL-VALUE` is the value of the credential.
-	<p class="note"><strong>Note</strong>: You can provide multiple credentials as a JSON list. For example, <code>{"MY\_CREDHUB\_CRED": "1234", "MY\_CREDHUB\_CRED2": "5678"}</code>.</p>
+	<p class="note"><strong>Note</strong>: You can provide multiple credentials as a JSON list. This JSON list has a maximum size of 64 KB. For example, <code>{"MY\_CREDHUB\_CRED": "1234", "MY\_CREDHUB\_CRED2": "5678"}</code>.</p>
 	<br><br>
 	<pre class="terminal">
 	cf create-service credhub default my-credhub-instance \


### PR DESCRIPTION
Credentials in CredHub have a size limit of 64 KB. We would like to make it clear to users that this limit exists.