### PR TITLE
Add relese notes for broker v1.5.1

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -38,19 +38,19 @@ The following table provides version and version-support information about CredH
     <th>Details</th>
     <tr>
         <td>Tile version</td>
-        <td>v1.5.0</td>
+        <td>v1.5.1</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td>March 16, 2021</td>
+        <td>September 7, 2021</td>
     </tr>
     <tr>
         <td>Software component version</td>
-        <td>v1.5.0</td>
+        <td>v1.5.1</td>
     </tr>
     <tr>
         <td>Compatible Ops Manager versions</td>
-        <td>2.7, 2.9, and 2.10</td>
+        <td>2.10</td>
     </tr>
     <tr>
         <td>Compatible TAS for VMs versions</td>

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -11,13 +11,23 @@ CredHub Service Broker v1.5 is the long-term supported (LTS) version of CredHub 
 
 Over the lifecycle of CredHub Service Broker v1.5, VMware will release security patches that occasionally include bug fixes and maintenance updates.
 
+##<a id="1-5-1"></a> v1.5.1
+
+**Release Date:** September 7, 2021
+
+### Resolved Issues
+
++ The `unbind` request no longer fails if the service is already unbound.
+
+### Known Issues
+
+There are no known issues for this release.
+
 ##<a id="1-5-0"></a> v1.5.0
 
 **Release Date:** March 16, 2021
 
 ### Resolved Issues
-
-+ The `unbind` request no longer fails if the service is already unbound.
 
 + The `deprovision` request no longer fails if the service is already deprovisioned.
 


### PR DESCRIPTION
- A fix was not successful on v1.5.0, so added the ultimate fix on
v1.5.1
- only ops manager 2.10 is supported now