### PR TITLE
fix: ambiguity in credential update

### DIFF
--- a/using.html.md.erb
+++ b/using.html.md.erb
@@ -102,7 +102,7 @@ To create a service instance of the CredHub Service Broker and bind it to your a
 
 To update credentials in an existing CredHub Service Broker service instance:
 
-1. Do the update:
+1. Run:
 
     ```console
     cf update-service SERVICE-INSTANCE \

--- a/using.html.md.erb
+++ b/using.html.md.erb
@@ -100,9 +100,9 @@ To create a service instance of the CredHub Service Broker and bind it to your a
 
 ## <a id='update'></a> Update Credentials
 
-To update the credentials in a CredHub Service Broker service instance:
+To update credentials in an existing CredHub Service Broker service instance:
 
-1. Create a CredHub Service Broker service instance by running:
+1. Do the update:
 
     ```console
     cf update-service SERVICE-INSTANCE \


### PR DESCRIPTION
* The first step looks like an inappropriate copy/paste from the first section, causing a user to think the last section talked about creating an instance.

[#186124001]