### PR TITLE
fix: Obsolete link URLs

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -110,4 +110,4 @@ CredHub Service Broker has the following requirement:
 - Secure binding credentials enabled in runtime CredHub
 
 To enable secure binding credentials in runtime CredHub, see
-[Securing Services Instance Credentials with Runtime CredHub](https://docs.vmware.com/en/VMware-Tanzu-Application-Service/3.0/tas-for-vms/secure-si-creds.html).
+[Securing Services Instance Credentials with Runtime CredHub](https://docs.vmware.com/en/VMware-Tanzu-Application-Service/4.0/tas-for-vms/secure-si-creds.html).

--- a/installing.html.md.erb
+++ b/installing.html.md.erb
@@ -48,7 +48,7 @@ see <a href="https://docs.vmware.com/en/VMware-Tanzu-Application-Service/5.0/tas
 
 To install the CredHub Service Broker tile on the Tanzu Operations Manager Installation Dashboard, do the following:
 
-1. Download the product file from [Tanzu Network](https://network.tanzu.vmware.com/products/credhub-service-broker).
+1. Download the product file from [Broadcom Support Portal](https://support.broadcom.com/group/ecx/productdownloads?subfamily=CredHub%20Service%20Broker).
 
 1. Go to the Tanzu Operations Manager Installation Dashboard and click **Import a Product** to upload the product file.
 


### PR DESCRIPTION
- Replaced a non-existing TAS 3.0 doc URL with a TAS 4.0 doc URL.
- Changed a Tanzu Net download URL to Broadcom Support Portal download URL.

[#187832330]